### PR TITLE
Fix Pack Qty on Mouser, Fix Error on current dev iteration

### DIFF
--- a/inventree_supplier_panel/mouser.py
+++ b/inventree_supplier_panel/mouser.py
@@ -35,7 +35,7 @@ class Mouser():
         part_data['MPN'] = response['SearchResults']['Parts'][0]['ManufacturerPartNumber']
         part_data['URL'] = response['SearchResults']['Parts'][0]['ProductDetailUrl']
         part_data['lifecycle_status'] = response['SearchResults']['Parts'][0]['LifecycleStatus']
-        part_data['pack_quantity'] = response['SearchResults']['Parts'][0]['Mult']
+        part_data['pack_quantity'] = Mouser.get_mouser_pack_size(self, response['SearchResults']['Parts'][0]) or response['SearchResults']['Parts'][0]['Mult']
         part_data['description'] = response['SearchResults']['Parts'][0]['Description']
         part_data['package'] = Mouser.get_mouser_package(self, response['SearchResults']['Parts'][0])
         part_data['price_breaks'] = []
@@ -59,9 +59,22 @@ class Mouser():
         except Exception:
             return None
         for att in attributes:
-            if att['AttributeName'] == 'Verpackung':
+            if att['AttributeName'] == 'Packaging':
                 package = package + att['AttributeValue'] + ', '
         return (package)
+
+    # ------------------------------- get_mouser_pack_size --------------------------
+    # Extracts the pack size from the Mouser part data json
+    def get_mouser_pack_size(self, part_data):
+        package_size = 0
+        try:
+            attributes = part_data['ProductAttributes']
+        except Exception:
+            return None
+        for att in attributes:
+            if att['AttributeName'] == 'Standard Pack Qty':
+                package_size = att['AttributeValue']
+        return (package_size)
 
     # --------------------------- reformat_mouser_price --------------------------
     # We need a Mouser specific modification to the price answer because they put

--- a/inventree_supplier_panel/supplier_panel.py
+++ b/inventree_supplier_panel/supplier_panel.py
@@ -283,6 +283,7 @@ class SupplierCartPanel(PanelMixin, SettingsMixin, InvenTreePlugin, UrlsMixin):
                 self.status_code = 'Supplierpart with this SKU already exists'
                 return HttpResponse('OK')
 
+        part_data = None
         results, part_data = self.get_partdata(data['supplier'], data['sku'], 'exact')
         if (self.status_code != 200):
             return HttpResponse('OK')


### PR DESCRIPTION
This PR fixes an issue I'm seeing on my inventree setup where pack sizes from Mouser are commonly being set to 1. I know that the pack size should be relative to how many parts are on a reel, and this change addresses this by using the Standard Pack Qty attribute provided by the API. 

In addition to this, I fixed two bugs I found while working on the development version. 

The first one relates to the supplier revision, it may be a dirty fix but python errors out because it thinks it's trying to change a variable that's outside the scope of the function without the use of a global declaration. As we want the variable to be in the function scope, this change initializes that variable in the function scope before attempting to assign the supplier search result to it. 

The second bug seems to be a localization issue when pulling package types from Mouser. I do not know if Mouser returns localized key names in their API, but I had noticed that the package type was looking for a German localized JSON key name, and it was returning blank for my setup. This might be something that needs to be redone using inventree's localization functions, but again, I do not know if Mouser returns JSON keys in different languages. 